### PR TITLE
fix getUser() for first time login

### DIFF
--- a/imjoy-plugins/Task-Dashboard.imjoy.html
+++ b/imjoy-plugins/Task-Dashboard.imjoy.html
@@ -61,7 +61,7 @@
       })
       await auth0.loginWithPopup({audience: 'https://imjoy.eu.auth0.com/api/v2/'});
       //logged in. you can get the user profile like this:
-      const user = await auth0.getUser();
+      const user = await auth0.getUser({audience: 'https://imjoy.eu.auth0.com/api/v2/'});
       this.isAdmin = false;
       if(user){
         if(!user.email_verified){


### PR DESCRIPTION
`auth0.getUser()` alone can't get the user at first time login so `Dataset ID` and `Dataset Directory` fields are invisible for `admins` with their first-time login attempt.
Reproduce:
* Logout your account at https://imjoy.io/lite?plugin=https://github.com/imjoy-team/imjoy-cloud-annotation/blob/main/imjoy-plugins/Task-Dashboard.imjoy.html
* Login again with an admin account --> Dataset fields will be invisible.

This pull request is to fix the getUser() function for the first time login.

