### PR TITLE
Fix fail to getUser() for first-time login + update datasetInfo

### DIFF
--- a/imjoy-plugins/Task-Dashboard.imjoy.html
+++ b/imjoy-plugins/Task-Dashboard.imjoy.html
@@ -275,7 +275,7 @@
               "owners": taskInfo.owners,
               "dataset_visibility": taskInfo.task_visibility
             }
-            await this.client.post(`${this.baseUrl}/dataset/${taskInfo.id}/update`, taskInfo)
+            await this.client.post(`${this.baseUrl}/dataset/${taskInfo.id}/update`, datasetInfo)
             api.showMessage('Task saved.')
           }
           

--- a/imjoy-plugins/Task-Dashboard.imjoy.html
+++ b/imjoy-plugins/Task-Dashboard.imjoy.html
@@ -8,7 +8,7 @@
     "type": "window",
     "tags": [],
     "ui": "",
-    "version": "0.1.24",
+    "version": "0.1.25",
     "cover": "",
     "description": "[TODO: describe this plugin with one sentence.]",
     "icon": "extension",
@@ -61,7 +61,7 @@
       })
       await auth0.loginWithPopup({audience: 'https://imjoy.eu.auth0.com/api/v2/'});
       //logged in. you can get the user profile like this:
-      const user = await auth0.getUser();
+      const user = await auth0.getUser({audience: 'https://imjoy.eu.auth0.com/api/v2/'}); // fix getUser() at first time login
       this.isAdmin = false;
       if(user){
         if(!user.email_verified){
@@ -269,6 +269,13 @@
           else{
             // update an existing task
             await this.client.post(`${this.baseUrl}/task/${taskInfo.id}/update`, taskInfo)
+            const datasetInfo = {
+              "white_list": taskInfo.white_list,
+              "black_list": taskInfo.black_list,
+              "owners": taskInfo.owners,
+              "dataset_visibility": taskInfo.task_visibility
+            }
+            await this.client.post(`${this.baseUrl}/dataset/${taskInfo.id}/update`, taskInfo)
             api.showMessage('Task saved.')
           }
           


### PR DESCRIPTION
This pull request fixes 2 problems:

1. auth0.getUser() alone can't get the user at first-time login so Dataset ID and Dataset Directory fields are invisible for admins with their first-time login attempt.
Issue reproduction:
* Logout your account at https://imjoy.io/lite?plugin=https://github.com/imjoy-team/imjoy-cloud-annotation/blob/main/imjoy-plugins/Task-Dashboard.imjoy.html
* Login again with an admin account --> Dataset fields will be invisible.

2. datasetInfo json file remains unchanged when we update on Task Manager.
Some fields related to datasetInfo such as data_visibility, sample_visibility, owners, whitelist, blacklist are not updated.

Besides, I think there is a back-end problem with first-time task creation, together with issue number 2 mentioned above, which causes the problem in issue #10.
